### PR TITLE
Improve command line binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,37 @@ var formattedCode = esformatter.format(codeStr, options);
 
 ### CLI
 
-You can also use the simple CLI to process `stdin` and `stdout`:
+You can also use the simple CLI to process `stdin` and `stdout` or reading from file:
 
+`stdin`
 ```sh
 # format "test.js" and output result to stdout
 cat test.js | esformatter
+# format "test.js" using options in "options.json" and output result to stdout
+cat test.js | esformatter --config options.json
 # process "test.js" and writes to "test.out.js"
 esformatter < test.js > test.out.js
 ```
+
+`file`
+````sh
+# format "test.js" and output result to stdout
+esformatter test.js
+# format "test.js" using options in "options.json" and output result to stdout
+esformatter --config options.json test.js
+# process "test.js" and writes to "test.out.js"
+esformatter test.js > test.out.js
+````
+
+````sh
+# Usage information
+esformatter --help
+esformatter -h
+
+# Version number
+esformatter --version
+esformatter -v
+````
 
 CLI will be highly improved after we complete the basic features of the
 library. We plan to add support for local/global settings and some flags to

--- a/bin/esformatter
+++ b/bin/esformatter
@@ -1,19 +1,65 @@
 #!/usr/bin/env node
 
+"use strict";
+
 var esformatter = require('../lib/esformatter');
+var cli = require('cli');
+var path = require('path');
+var fs = require('fs');
+
+var ARGV = {
+    // it would be nice to say that this is a file instead of a string, but it doesn't like some paths in windows
+    'config': ['c', 'Custom configuration object', 'string', null]
+};
 
 
-var buf = '';
+cli.setApp(path.join(__dirname, '/../package.json'));
+cli.enable('help', 'version');
+cli.setUsage(cli.app + ' [OPTIONS] <fileName>');
 
-process.stdin.on('data', function(chunk){
-    buf += chunk;
-});
+var options = cli.parse(ARGV);
+var config = loadConfigFile(options.config);
 
-process.stdin.on('end', function(){
-    var result = esformatter.format(buf);
+
+if (cli.args.length === 0) {
+    // Read from stdinput
+    cli.withStdin(formatToConsole);
+} else {
+    // Read from file
+    for (var i = 0, len = cli.args.length; i < len; i += 1) {
+        var toFormat = loadFile(cli.args[i]);
+        formatToConsole(toFormat);
+    }
+}
+
+
+function loadFile (file) {
+    try {
+        return fs.readFileSync(file).toString();
+    } catch (ex) {
+        cli.error("Can't read source file: " + file + "\nException: " + ex.message);
+        process.exit(2);
+    }
+}
+
+function loadConfigFile (file) {
+    if (!file) {
+        return;
+    }
+    if (!fs.existsSync(file)) {
+        cli.error("Can't find configuration file: " + file + "\nFile doesn't exist");
+        process.exit(1);
+    } else {
+        try {
+            return JSON.parse(fs.readFileSync(file).toString());
+        } catch (ex) {
+            cli.error("Can't parse configuration file: " + file + "\nException: " + ex.message);
+            process.exit(1);
+        }
+    }
+}
+
+function formatToConsole (source) {
+    var result = esformatter.format(source, config);
     console.log(result);
-    process.exit(0);
-});
-
-process.stdin.resume();
-
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   },
   "dependencies": {
     "mout": "~0.5",
-    "rocambole": "~0.2"
+    "rocambole": "~0.2",
+    "cli": "~0.4"
   },
   "license": "MIT"
 }

--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -1,0 +1,95 @@
+/*jshint node:true*/
+/*global describe:false, it:false*/
+"use strict";
+
+var spawn = require('child_process').spawn;
+var path = require('path');
+var fs = require('fs');
+var expect = require('chai').expect;
+var helpers = require('./helpers');
+
+describe('Command line interface', function () {
+    var filePath, configPath;
+
+    /**
+     * Spawn a child process calling the bin file with the specified options
+     * @param {String} options Same as you would pass in the command line
+     * @param {String} input Standard input
+     * @param {Function} testCallback It receives the formatted file
+     */
+    var spawnEsformatterWith = function (options, input, testCallback) {
+        var args = [path.join(__dirname + '/../bin/esformatter')];
+        if (typeof options === 'function') {
+            testCallback = options;
+            options = null;
+        } else if (typeof input === 'function') {
+            testCallback = input;
+            input = null;
+        }
+        if (options) {
+            args = args.concat(options.split(" "));
+        }
+        it('spawn esformatter with ' + options, function (mochaCallback) {
+            var childprocess = spawn('node', args, {
+                stdio : ['pipe', 'pipe', 'pipe']
+            });
+            var output = "";
+            var errorInChildProcess = "";
+            childprocess.stdout.on('data', function (data) {
+                output += data.toString();
+            });
+            childprocess.stderr.on('data', function (data) {
+                errorInChildProcess += data.toString();
+            });
+            childprocess.on('exit', function () {
+                if (errorInChildProcess) {
+                    mochaCallback(new Error(errorInChildProcess));
+                } else {
+                    try {
+                        // There is an extra line feed from piping stdout
+                        testCallback(helpers.lineFeed(output.replace(/\n$/, '')));
+                        mochaCallback();
+                    } catch (ex) {
+                        mochaCallback(ex);
+                    }
+                }
+            });
+            if (input) {
+                try {
+                    var textInput = fs.readFileSync(input, 'utf-8');
+                    childprocess.stdin.write(textInput);
+                    childprocess.stdin.end();
+                } catch (ex) {
+                    mochaCallback(ex);
+                }
+            }
+        });
+    };
+
+
+    // Format a file with default options
+    filePath = path.join(__dirname + '/compare/default/array_expression-in.js');
+    spawnEsformatterWith(filePath, function (formattedFile) {
+        expect( formattedFile ).to.equal( helpers.readOut('/default/array_expression') );
+    });
+
+    // Format a file specifying some options
+    filePath = path.join(__dirname + '/compare/custom/basic_function_indent-in.js');
+    configPath = path.join(__dirname + '/compare/custom/basic_function_indent-config.json');
+    spawnEsformatterWith("--config " + configPath + " " + filePath, function (formattedFile) {
+        expect( formattedFile ).to.equal( helpers.readOut('/custom/basic_function_indent') );
+    });
+
+    // Format a file from standard input
+    filePath = path.join(__dirname + '/compare/default/assignment_expression-in.js');
+    spawnEsformatterWith(null, filePath, function (formattedFile) {
+        expect( formattedFile ).to.equal( helpers.readOut('/default/assignment_expression') );
+    });
+
+    // Format a file from standard input with options
+    filePath = path.join(__dirname + '/compare/custom/call_expression-in.js');
+    configPath = path.join(__dirname + '/compare/custom/call_expression-config.json');
+    spawnEsformatterWith("--config " + configPath, filePath, function (formattedFile) {
+        expect( formattedFile ).to.equal( helpers.readOut('/custom/call_expression') );
+    });
+});

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -35,7 +35,7 @@ exports.readConfig = function(id){
 
 
 exports.readFile = function(path){
-    return _fs.readFileSync(path).toString();
+    return exports.lineFeed(_fs.readFileSync(path).toString());
 };
 
 
@@ -59,3 +59,6 @@ exports.mkdir = function(dir){
     }
 };
 
+exports.lineFeed = function(text){
+    return text.replace(/\r\n?|[\n\u2028\u2029]/g, "\n");
+};

--- a/test/runner.js
+++ b/test/runner.js
@@ -28,6 +28,7 @@ if (process.env.npm_config_invert) {
 
 
 m.addFile('test/format.spec.js');
+m.addFile('test/cli.spec.js');
 
 m.run(function(err){
     var exitCode = err? 1 : 0;


### PR DESCRIPTION
Give the possibility to specify from the command line a file(s) to be formatted with optional configuration.

As written in the `README` it's now possible to use

``` sh
# format "test.js" and output result to stdout
esformatter test.js
# format "test.js" using options in "options.json" and output result to stdout
esformatter --config options.json test.js
# process "test.js" and writes to "test.out.js"
esformatter test.js > test.out.js
```

This is an addition to the previos behavior that still works as before.

It is actaully possible to format multiple files at the same time, but I don't see the advantage of doing it

``` sh
esformatter file1.js file2.js file3.js
# equivalent to    cat file1.js file2.js file3.js | esformatter 
```

Of course you can use

``` sh
# Usage information
esformatter --help
esformatter -h

# Version number
esformatter --version
esformatter -v
```

I've added also unit tests to verify that the command line does its job and modified slightly the helpers utility to work on windows as well (damn carriage returns).

This should close #25, #26 and #27

Thanks for the project, I love it!

Please let me know if you want me to change the formatting or follow some different coding styles :wink: 
