### PR TITLE
WIP: jQuery preset

### DIFF
--- a/test/compare/jquery/jquery-in.js
+++ b/test/compare/jquery/jquery-in.js
@@ -1,0 +1,94 @@
+(function( $, undefined ) {
+
+switch ( event.keyCode ) {
+case $.ui.keyCode.ENTER:
+case $.ui.keyCode.SPACE:
+	x();
+	break;
+case $.ui.keyCode.ESCAPE:
+	y();
+	break;
+default:
+	z();
+}
+
+functionl.call( "argument", function( param1, param2 ) {
+	// comment
+	var var1, var2,
+		var3 = [],
+		var4 = {},
+		// comment
+		var5 = [ var1, var2, var3 ],
+		var6 = [
+			// multi-line array literal needs indent
+			"jquery.ui.core.js",
+			"jquery.ui.widget.js"
+		];
+	for ( var1 in var4 ) {
+		// comment
+		doSomething[ x ] = something();
+	}
+	// comment
+	call();
+	call(function(){});
+	call(function() {
+		something();
+		return "a multi line string" +
+			"should be allowed to stay" +
+			"on multiple lines";
+	});
+	foo([ "alpha", "beta" ]);
+});
+
+define( name, {
+	props: {
+		// comment
+		x: 1,
+		y: 2,
+
+		change: null,
+		select: null
+	},
+
+	_create: function() {
+		var var1,
+			var2 = "x",
+			var3 = call([]),
+			var4 = call({});
+
+		// line comment
+		this.doSomething();
+
+		this.element
+			.add()
+			.set({
+				// line comment
+				// one more
+				prop: "value"
+			});
+
+		if ( this === that ) {
+			x = ( value / 1 ) * ( y / x );
+		}
+		x = { inline: "object" };
+
+		// tertiary expressions, not defined yet: https://github.com/jquery/contribute.jquery.org/issues/45
+
+		// inline
+		parts = typeof value === "string" ? value.split( " " ) : [ value ];
+
+		// line break after question mark and colon:
+		return rnumnonpx.test( computed ) ?
+			jQuery( elem ).position()[ prop ] + "px" :
+			computed;
+
+		// line break after colon:
+		return this.indeterminate ? false :
+			Math.min( this.options.max, Math.max( this.min, newValue ) );
+
+		return amount + ( amount > 1 ? " results are" : " result is" ) +
+			" available, use up and down arrow keys to navigate.";
+	}
+});
+
+}( jQuery ));

--- a/test/compare/jquery/jquery-out.js
+++ b/test/compare/jquery/jquery-out.js
@@ -1,0 +1,94 @@
+(function( $, undefined ) {
+
+switch ( event.keyCode ) {
+case $.ui.keyCode.ENTER:
+case $.ui.keyCode.SPACE:
+	x();
+	break;
+case $.ui.keyCode.ESCAPE:
+	y();
+	break;
+default:
+	z();
+}
+
+functionl.call( "argument", function( param1, param2 ) {
+	// comment
+	var var1, var2,
+		var3 = [],
+		var4 = {},
+		// comment
+		var5 = [ var1, var2, var3 ],
+		var6 = [
+			// multi-line array literal needs indent
+			"jquery.ui.core.js",
+			"jquery.ui.widget.js"
+		];
+	for ( var1 in var4 ) {
+		// comment
+		doSomething[ x ] = something();
+	}
+	// comment
+	call();
+	call(function() {});
+	call(function() {
+		something();
+		return "a multi line string" +
+			"should be allowed to stay" +
+			"on multiple lines";
+	});
+	foo([ "alpha", "beta" ]);
+});
+
+define( name, {
+	props: {
+		// comment
+		x: 1,
+		y: 2,
+
+		change: null,
+		select: null
+	},
+
+	_create: function() {
+		var var1,
+			var2 = "x",
+			var3 = call([]),
+			var4 = call({});
+
+		// line comment
+		this.doSomething();
+
+		this.element
+			.add()
+			.set({
+				// line comment
+				// one more
+				prop: "value"
+			});
+
+		if ( this === that ) {
+			x = ( value / 1 ) * ( y / x );
+		}
+		x = { inline: "object" };
+
+		// tertiary expressions, not defined yet: https://github.com/jquery/contribute.jquery.org/issues/45
+
+		// inline
+		parts = typeof value === "string" ? value.split( " " ) : [ value ];
+
+		// line break after question mark and colon:
+		return rnumnonpx.test( computed ) ?
+			jQuery( elem ).position()[ prop ] + "px" :
+			computed;
+
+		// line break after colon:
+		return this.indeterminate ? false :
+			Math.min( this.options.max, Math.max( this.min, newValue ) );
+
+		return amount + ( amount > 1 ? " results are" : " result is" ) +
+			" available, use up and down arrow keys to navigate.";
+	}
+});
+
+}( jQuery ));


### PR DESCRIPTION
A list of issues to take care of to get to #19:
- [x] More whitespace within array declarations, e.g. `[ x, y ]`. It looks like there's no config for this, so needs to be added. WIP: #53
- [x] More whitespace within `for( x in y )`. There is ForInStatement, ForInStatementExpression, ForInStatementOpeningBrace and ForInStatementClosingBrace, all set to `1` by default, yet the necessary whitespace isn't added. Either I misunderstand what these properties are supposed to do and we need extra config, or they are buggy. WIP: #52
- [x] More whitespace within if statements, e.g. `if ( x === y )`. Similar to `for`, there's IfStatementConditional, IfStatementOpeningBrace and IfStatementClosingBrace, but all of these are set to `1` by default, yet the whitespace isn't added. WIP: #51 
- [x] Multi line tertiary expressions (aka ConditionalExpression) need improvements, see #6. WIP: #55
- [x] Similar to for and if, more whitespace within inline expressions with braces, e.g. `( value / 1 )`. I don't see any config for these. Issue: #60
- [x] Multiple variable declarations without assignments are supposed to go on one line. This needs a new configuration option. Issue #63. WIP: #71
- [x] There's an exception for array, function and object parameters, which don't get extra whitespace before and after. This needs a new config option. WIP: #66
- [x] Top level function scope isn't indented. Needs a new config option. [Also needs to be added to the jQuery Style Guide](https://github.com/jquery/contribute.jquery.org/issues/53). WIP: #69
- [x] Whitespace inside object access using array notation, aka MemberExpression, e.g. obj[ prop ]. WIP: #67
- [x] Whitespace before opening brace of function expression inside call expression, issue #64. WIP: #65
- [x] Indented comments loose their indentation. This must be a bug. I'm not sure though why it fails here, while it seems to work in the function_declaration test. Maybe because it uses tabs for indenting, while the existing test has spaces? Could be related to #38. ~~WIP: #50~~ Issue #68
- [x] Format switch statements. See #42. [Also needs to be added to the jQuery Style Guide](https://github.com/jquery/contribute.jquery.org/issues/52). WIP: #70
- [x] Proper indent for multi-line block comments, issue #10, WIP: #58 
- [x] BlockComment should not be indented inside function parameters, issue #36, WIP: #57
- [x] Comment indentation on chained calls, WIP: #65 
- [x] Multi-line object argument inside indented method call lacks indent, issue #72 WIP: #81
- [x] Create an actual preset. WIP: #92
- [x] Update preset to set properties for SwitchStatement, f811132f1361e174e484256bd0e3b1c98eac60f1
- [x] Comment indentation has bugs, #102
- [x] Parens inside ReturnStatment don't adhere to ExpressionOpeningParentheses and ExpressionClosingParentheses, #99, WIP #119
- [x] Multi-line array initializer has wrong indentation, #100
- [x] empty array literal in combination with member expression causes space inside the literal, #109 
- [ ] Allow objects expressions on one line (if short enough), issue #73, #84
- [x] Allow strings to be split on multiple lines, probably can be addressed by #84 as well
- [x] Exception for object expression as argument, regressed, #121
