### PR TITLE
Indent comments within ObjectExpressions within CallExpressions

### DIFF
--- a/lib/util/indent.js
+++ b/lib/util/indent.js
@@ -142,7 +142,9 @@ exports.getCommentIndentLevel = function (node) {
     var level = 0;
     while (node) {
         if ( _curOpts[node.type] ) {
-            if (!(node.parent.type in BYPASS_CHILD_INDENT) &&
+            if (!(node.parent.type in BYPASS_CHILD_INDENT &&
+                // exclude ObjectExpression within CallExpression from bypassing
+                !(node.parent.type === "CallExpression" && node.type === "ObjectExpression")) &&
                 !(_ast.getNodeKey(node) in SPECIAL_SUB_TYPES)) {
                 level++;
             }

--- a/test/compare/default/obj_expression-in.js
+++ b/test/compare/default/obj_expression-in.js
@@ -10,7 +10,12 @@ ipsum({flag:true,other:false});
 ipsum({flag:true,other:false},789,'bar');
 
 
-var obj = {foo:"bar", 'lorem'   :  123,     
+var obj = {foo:"bar", 'lorem'   :  123,
     dolor :new Date()
 , "re": /\w+/g}    ;
 
+// ObjectEpression within CallExpression needs to indent comments
+declare({
+// comment
+create: {}
+});

--- a/test/compare/default/obj_expression-out.js
+++ b/test/compare/default/obj_expression-out.js
@@ -30,3 +30,8 @@ var obj = {
     "re" : /\w+/g
 };
 
+// ObjectEpression within CallExpression needs to indent comments
+declare({
+    // comment
+    create : {}
+});


### PR DESCRIPTION
This addresses the one bug I found as part of #46. My solution seems more like a workaround, but it fixes the problem and I've added tests, so this could land and get improved later on.
