### PR TITLE
Allow more customization on array expression whitespace.

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -505,6 +505,8 @@ exports.DoWhileStatement = function(node){
 
 exports.ArrayExpression = function(node){
     if (node.elements.length) {
+        _ws.aroundIfNeeded(node.startToken, 'ArrayExpressionOpening');
+        _ws.aroundIfNeeded(node.endToken, 'ArrayExpressionClosing');
         node.elements.forEach(function(el){
             var next = _tk.findNextNonEmpty(el.endToken);
             if (next.value === ',') {

--- a/lib/preset/default.json
+++ b/lib/preset/default.json
@@ -126,6 +126,8 @@
         "removeTrailing" : 1,
 
         "before" : {
+            "ArrayExpressionOpening" : 0,
+            "ArrayExpressionClosing" : 0,
             "ArrayExpressionComma" : 0,
             "ArgumentComma" : 0,
             "ArgumentList" : 0,
@@ -180,6 +182,8 @@
         },
 
         "after" : {
+            "ArrayExpressionOpening" : 0,
+            "ArrayExpressionClosing" : 0,
             "ArrayExpressionComma" : 1,
             "ArgumentComma" : 1,
             "ArgumentList" : 0,

--- a/test/compare/custom/array_expression-config.json
+++ b/test/compare/custom/array_expression-config.json
@@ -1,0 +1,12 @@
+{
+    "whiteSpace" : {
+        "before" : {
+            "ArrayExpressionOpening" : 0,
+            "ArrayExpressionClosing" : 1
+        },
+        "after" : {
+            "ArrayExpressionOpening" : 1,
+            "ArrayExpressionClosing" : 0
+        }
+    }
+}

--- a/test/compare/custom/array_expression-in.js
+++ b/test/compare/custom/array_expression-in.js
@@ -1,0 +1,22 @@
+[
+
+];
+
+[1,2,3];
+
+[1,2,[3,4,[5,6,[7,8,9]]]];
+
+function fn(){
+    return [4,5,[6,  7 , 8 ]];
+}
+
+// issue #12
+var tuples = [
+    // comment test
+    ["resolve", "done", "bla", "resolved"],
+        ["reject", "fail", "lorem", "rejected"],
+    [
+["lorem", "ipsum"]
+    ],
+    ["notify", "progress", "ipsum"]
+];

--- a/test/compare/custom/array_expression-out.js
+++ b/test/compare/custom/array_expression-out.js
@@ -1,0 +1,20 @@
+[];
+
+[ 1, 2, 3 ];
+
+[ 1, 2, [ 3, 4, [ 5, 6, [ 7, 8, 9 ] ] ] ];
+
+function fn() {
+    return [ 4, 5, [ 6, 7, 8 ] ];
+}
+
+// issue #12
+var tuples = [
+    // comment test
+    [ "resolve", "done", "bla", "resolved" ],
+    [ "reject", "fail", "lorem", "rejected" ],
+    [
+        [ "lorem", "ipsum" ]
+    ],
+    [ "notify", "progress", "ipsum" ]
+];


### PR DESCRIPTION
Add ArrayExpressionOpening and ArrayExpressionClosing to allow whitespace
insertion inside the expression.

Somewhat similar to #51 and #52, required for #19.
