### PR TITLE
Conditional statement - fixes #6

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -467,13 +467,18 @@ exports.ConditionalExpression = function(node){
     var questionMark = _tk.findNext(node.test.endToken, '?');
     var colon = _tk.findNext(node.consequent.endToken, ':');
 
-    _tk.removeWsBrInBetween(node.test.endToken, _tk.findNextNonEmpty(questionMark));
-    _tk.removeWsBrInBetween(node.consequent.endToken, _tk.findNextNonEmpty(colon));
+    _tk.removeInBetween(node.test.endToken, _tk.findNextNonEmpty(questionMark), _tk.isWs);
+    _tk.removeInBetween(node.consequent.endToken, _tk.findNextNonEmpty(colon), _tk.isWs);
 
     _ws.beforeIfNeeded(questionMark, _ws.needsAfter('ConditionalExpressionTest'));
     _ws.afterIfNeeded(questionMark, _ws.needsBefore('ConditionalExpressionConsequent'));
     _ws.beforeIfNeeded(colon, _ws.needsAfter('ConditionalExpressionConsequent'));
     _ws.afterIfNeeded(colon, _ws.needsBefore('ConditionalExpressionAlternate'));
+
+    var indentLevel = _indent.getLevelLoose(node) + 1;
+    // find first token of each, since startToken might be after parenthesis, as above
+    _indent.ifNeeded(_tk.findPrev(node.consequent.startToken, _tk.isEmpty).next, indentLevel);
+    _indent.ifNeeded(_tk.findPrev(node.alternate.startToken, _tk.isEmpty).next, indentLevel);
 };
 
 

--- a/lib/util/indent.js
+++ b/lib/util/indent.js
@@ -139,6 +139,11 @@ function getLevelLoose(node) {
 
 
 exports.getCommentIndentLevel = function (node) {
+    // indent comments within multi line conditional expressions
+    if (node.type === "ConditionalExpression") {
+        // bypass all the special subtype exceptions below
+        return getLevelLoose(node) + 1;
+    }
     var level = 0;
     while (node) {
         if ( _curOpts[node.type] ) {

--- a/test/compare/custom/conditional_expression-in.js
+++ b/test/compare/custom/conditional_expression-in.js
@@ -1,8 +1,7 @@
 // test the opposite of default settings
 a?foo():bar();
 
-b = (dolor!==amet)  ?  'ipsum':
-    'dolor';
+b = (dolor!==amet)  ?  'ipsum':       'dolor';
 
 if(true){
 c = !a ?(!foo?d  :   function(){

--- a/test/compare/default/conditional_expression-in.js
+++ b/test/compare/default/conditional_expression-in.js
@@ -1,7 +1,6 @@
 a?foo():bar();
 
-b = (dolor!==amet)  ?  'ipsum':
-    'dolor';
+b = (dolor!==amet)  ?  'ipsum': 'dolor';
 
 if(true){
 c = !a ?(!foo?d  :   function(){
@@ -14,15 +13,26 @@ foo.a = true; a?foo() : bar()
 
 
 // from jquery
-jQuery.prototype = {
-    get: function( num ) {
-        return num == null ?
+x = function(num) {
+    return num == null ?
 
-            // Return a 'clean' array
-            this.toArray() :
+        // Return a 'clean' array
+        this.toArray() :
 
-            // Return just the object
-            ( num < 0 ? this[ this.length + num ] : this[ num ] );
-    }
-};
+        // Return just the object
+        (object);
+}
 
+function x() {
+    x.test(y) ?
+        a :
+        b;
+}
+
+num == null ?
+
+    // Return a 'clean' array
+    this.toArray() :
+
+    // Return just the object
+    ( num < 0 ? this[ this.length + num ] : this[ num ] );

--- a/test/compare/default/conditional_expression-out.js
+++ b/test/compare/default/conditional_expression-out.js
@@ -14,15 +14,26 @@ a ? foo() : bar()
 
 
 // from jquery
-jQuery.prototype = {
-    get : function(num) {
-        return num == null ?
+x = function(num) {
+    return num == null ?
 
-            // Return a 'clean' array
-            this.toArray() :
+        // Return a 'clean' array
+        this.toArray() :
 
-            // Return just the object
-            (num < 0 ? this[this.length + num] : this[num]);
-    }
-};
+        // Return just the object
+        (object);
+}
 
+function x() {
+    x.test(y) ?
+        a :
+        b;
+}
+
+num == null ?
+
+    // Return a 'clean' array
+    this.toArray() :
+
+    // Return just the object
+    (num < 0 ? this[this.length + num] : this[num]);


### PR DESCRIPTION
Comments and line breaks inside ConditionalExpression. Fixes #6

Removes the removal of line breaks, since we don't know when those should be added back. Instead the consequent and alternate after a line break are indented properly. Accordingly I had to remove the line breaks in single-line test.

Getting comments to intend properly as well required a special path within indent.getCommentIndentLevel. All attempts to modify the existing logic failed to provide useful results. Instead of now applies the same logic to figure out the level as for the code itself.
