### PR TITLE
BlockComment should not be indented inside function parameters

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -213,9 +213,14 @@ exports.VariableDeclaration = function(node){
     _tk.eachInBetween(node.startToken, node.endToken, function(token){
         // ASI messes with endToken + comments since comment isn't considered
         // a node "terminator"
-        if (_tk.isComment(token) &&
-            (token.next !== node.endToken || ! _tk.isBr(node.endToken))) {
+        // but don't indent inline block comments
+        if (_tk.isComment(token) && _tk.isBr(token.next) &&
+            (token.next !== node.endToken || !_tk.isBr(node.endToken))) {
             _indent.before(token, indentLevel);
+        }
+        // remove whitespace added earlier in front of inline block comments
+        if (_tk.isComment(token) && _tk.isWs(token.prev)) {
+            _tk.remove(token.prev);
         }
     });
 

--- a/test/compare/default/function_expression-in.js
+++ b/test/compare/default/function_expression-in.js
@@ -27,3 +27,8 @@ var add = function(a, b)
     return a + b;
 }
 
+var obj = {
+    then: function( /* fnDone, fnFail, fnProgress */ ) {
+        var fns = arguments;
+    }
+};

--- a/test/compare/default/function_expression-out.js
+++ b/test/compare/default/function_expression-out.js
@@ -33,3 +33,8 @@ var add = function(a, b) {
     return a + b;
 }
 
+var obj = {
+    then : function(/* fnDone, fnFail, fnProgress */) {
+        var fns = arguments;
+    }
+};


### PR DESCRIPTION
Fixes #36

This enhances the workaround for dealing with comments inside variable declarations.
