### PR TITLE
Properly indent multi-line block comments

### DIFF
--- a/lib/esformatter.js
+++ b/lib/esformatter.js
@@ -86,7 +86,12 @@ function processComments(node){
             if (token.prev && token.prev.type === 'WhiteSpace') {
                 _tk.remove(token.prev);
             }
-            _indent.ifNeeded(token, _indent.getCommentIndentLevel(node));
+            var level = _indent.getCommentIndentLevel(node);
+            _indent.ifNeeded(token, level);
+            if (token.type === 'BlockComment') {
+                // format multi line block comments
+                token.raw = token.raw.replace(/\n\*/g, "\n" + _indent.getIndent(level) + " *");
+            }
             _ws.beforeIfNeeded(token, token.type);
             // we avoid processing same comment multiple times since same
             // comment will be part of multiple nodes (all comments are inside

--- a/test/compare/default/comments-in.js
+++ b/test/compare/default/comments-in.js
@@ -5,7 +5,7 @@
  */
 if (true) {
 // line comment, 1 indent
-/*
+/**
  * block comment, 1 indent
  */
 if (true) {

--- a/test/compare/default/comments-out.js
+++ b/test/compare/default/comments-out.js
@@ -5,7 +5,7 @@
  */
 if (true) {
     // line comment, 1 indent
-    /*
+    /**
      * block comment, 1 indent
      */
     if (true) {


### PR DESCRIPTION
Fixes #10

Edits the comment's raw value to insert the correct indentation.
