### PR TITLE
Fix default for whiteSpace.after.PropertyName.

### DIFF
--- a/lib/preset/default.json
+++ b/lib/preset/default.json
@@ -229,7 +229,7 @@
             "ElseIfStatementOpeningBrace" : 1,
             "ElseIfStatementClosingBrace" : 1,
             "LogicalExpressionOperator" : 1,
-            "PropertyName" : 1,
+            "PropertyName" : 0,
             "ParameterComma" : 1,
             "ParameterList" : 0,
             "TryOpeningBrace" : 1,

--- a/test/compare/custom/call_expression-out.js
+++ b/test/compare/custom/call_expression-out.js
@@ -2,7 +2,7 @@ foo();
 
 bar( 1 ,'dolor' );
 ipsum( 3 ,{
-    amet : true
+    amet: true
 } ,'foo' );
 
 dolor = foo( 2 )

--- a/test/compare/custom/for_in_statement-out.js
+++ b/test/compare/custom/for_in_statement-out.js
@@ -16,7 +16,7 @@ for ( key in obj ) {
 
 // issue #13 : ForInStatement should not mess with inline object indent
 function iss13() {
-    for ( i in {submit : true, change : true, focusin : true} ) {
+    for ( i in {submit: true, change: true, focusin: true} ) {
         console.log(i);
     }
 }

--- a/test/compare/custom/obj_expression-config.json
+++ b/test/compare/custom/obj_expression-config.json
@@ -1,0 +1,7 @@
+{
+    "whiteSpace" : {
+        "after" : {
+            "PropertyName" : 1
+        }
+    }
+}

--- a/test/compare/custom/obj_expression-in.js
+++ b/test/compare/custom/obj_expression-in.js
@@ -1,0 +1,21 @@
+foo.bar.Baz(  {
+    method2: function () {}, prop   : 'dolor amet'
+    , prop2 : 123
+});
+
+
+function foo(a){ amet(123, a, {flag:true}); }
+ipsum({flag:true});
+ipsum({flag:true,other:false});
+ipsum({flag:true,other:false},789,'bar');
+
+
+var obj = {foo:"bar", 'lorem'   :  123,
+    dolor :new Date()
+, "re": /\w+/g}    ;
+
+// ObjectEpression within CallExpression needs to indent comments
+declare({
+// comment
+create: {}
+});

--- a/test/compare/custom/obj_expression-out.js
+++ b/test/compare/custom/obj_expression-out.js
@@ -1,0 +1,37 @@
+foo.bar.Baz({
+    method2 : function(){},
+    prop : 'dolor amet',
+    prop2 : 123
+});
+
+
+function foo(a) {
+    amet(123, a, {
+        flag : true
+    });
+}
+ipsum({
+    flag : true
+});
+ipsum({
+    flag : true,
+    other : false
+});
+ipsum({
+    flag : true,
+    other : false
+}, 789, 'bar');
+
+
+var obj = {
+    foo : "bar",
+    'lorem' : 123,
+    dolor : new Date(),
+    "re" : /\w+/g
+};
+
+// ObjectEpression within CallExpression needs to indent comments
+declare({
+    // comment
+    create : {}
+});

--- a/test/compare/default/call_expression-out.js
+++ b/test/compare/default/call_expression-out.js
@@ -2,7 +2,7 @@ foo();
 
 bar(1, 'dolor');
 ipsum(3, {
-    amet : true
+    amet: true
 }, 'foo');
 
 dolor = foo(2)

--- a/test/compare/default/for_in_statement-out.js
+++ b/test/compare/default/for_in_statement-out.js
@@ -16,7 +16,7 @@ for (key in obj) {
 
 // issue #13 : ForInStatement should not mess with inline object indent
 function iss13() {
-    for (i in {submit : true, change : true, focusin : true}) {
+    for (i in {submit: true, change: true, focusin: true}) {
         console.log(i);
     }
 }

--- a/test/compare/default/function_expression-out.js
+++ b/test/compare/default/function_expression-out.js
@@ -12,14 +12,14 @@ b = function doB(q, wer, ty) {
 }
 
 this.foo = {
-    bar : function() {
+    bar: function() {
         var r = function() {
             re();
             draw();
             return log('foo') + 'bar';
         };
     },
-    ipsum : function(amet) {
+    ipsum: function(amet) {
         return function() {
             amet()
         }

--- a/test/compare/default/obj_expression-out.js
+++ b/test/compare/default/obj_expression-out.js
@@ -1,37 +1,37 @@
 foo.bar.Baz({
-    method2 : function(){},
-    prop : 'dolor amet',
-    prop2 : 123
+    method2: function(){},
+    prop: 'dolor amet',
+    prop2: 123
 });
 
 
 function foo(a) {
     amet(123, a, {
-        flag : true
+        flag: true
     });
 }
 ipsum({
-    flag : true
+    flag: true
 });
 ipsum({
-    flag : true,
-    other : false
+    flag: true,
+    other: false
 });
 ipsum({
-    flag : true,
-    other : false
+    flag: true,
+    other: false
 }, 789, 'bar');
 
 
 var obj = {
-    foo : "bar",
-    'lorem' : 123,
-    dolor : new Date(),
-    "re" : /\w+/g
+    foo: "bar",
+    'lorem': 123,
+    dolor: new Date(),
+    "re": /\w+/g
 };
 
 // ObjectEpression within CallExpression needs to indent comments
 declare({
     // comment
-    create : {}
+    create: {}
 });

--- a/test/compare/default/var-out.js
+++ b/test/compare/default/var-out.js
@@ -45,8 +45,8 @@ var x = 33,
 
         // literal object
         obj = {
-            num : 123,
-            str : 'literal'
+            num: 123,
+            str: 'literal'
         };
 }());
 


### PR DESCRIPTION
Fixes #59

Removes whitespace between property names and the colon, to
match the Google JS Style Guide which the default preset implements.
