### PR TITLE
Always check whitespace around FunctionExpressionOpeningBrace. 

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -62,11 +62,10 @@ exports.FunctionExpression = function(node){
         }
         exports.Params(node.params);
 
+        _ws.aroundIfNeeded( node.body.startToken, 'FunctionExpressionOpeningBrace' );
         if (node.parent.type !== 'CallExpression') {
-            _ws.aroundIfNeeded( node.body.startToken, 'FunctionExpressionOpeningBrace' );
             _ws.aroundIfNeeded( node.endToken, 'FunctionExpressionClosingBrace' );
         } else {
-            _ws.afterIfNeeded( node.body.startToken, 'FunctionExpressionOpeningBrace' );
             _ws.beforeIfNeeded( node.endToken, 'FunctionExpressionClosingBrace' );
         }
 

--- a/test/compare/default/function_expression-in.js
+++ b/test/compare/default/function_expression-in.js
@@ -27,3 +27,8 @@ var add = function(a, b)
     return a + b;
 }
 
+call(    function(a)
+{
+    b();
+}
+);

--- a/test/compare/default/function_expression-out.js
+++ b/test/compare/default/function_expression-out.js
@@ -33,3 +33,6 @@ var add = function(a, b) {
     return a + b;
 }
 
+call(function(a) {
+    b();
+});

--- a/test/compare/default/if_statement-out.js
+++ b/test/compare/default/if_statement-out.js
@@ -40,7 +40,7 @@ if (foo === bar &&
     foo > bar) {
     foo = bar;
 }
-(function(){
+(function() {
     if (foo === bar &&
         //bla bla bla
         foo > bar) {

--- a/test/compare/default/iife-out.js
+++ b/test/compare/default/iife-out.js
@@ -1,4 +1,4 @@
-(function(i){
+(function(i) {
     function h(a, b, c, d, e) {
         this._listener = b;
         this._isOnce = c;

--- a/test/compare/default/var-out.js
+++ b/test/compare/default/var-out.js
@@ -32,7 +32,7 @@ var x = 33,
 
 
 // issue #31: multiple var declaration + function expression = wrong indent
-(function(){
+(function() {
     var
         // A central reference to the root jQuery(document)
         rootjQuery,


### PR DESCRIPTION
Fixes #64

This removes half the exception of FunctionExpression inside CallExpression.
While it's intended as a bugfix, it also changes a few unrelated tests to
match that style. This looks like a better default, matching what jQuery does,
and afaik not contradicting anything in the Google JS Style Guide.
