### PR TITLE
Add option to indent one level less when inside a function expression.

### DIFF
--- a/lib/preset/default.json
+++ b/lib/preset/default.json
@@ -11,7 +11,8 @@
         "ObjectExpression" : 1,
         "TryStatement" : 1,
         "WhileStatement" : 1,
-        "EmptyStatement" : 0
+        "EmptyStatement" : 0,
+        "TopLevelFunctionBlock" : 1
     },
 
 

--- a/lib/util/indent.js
+++ b/lib/util/indent.js
@@ -116,6 +116,7 @@ function getLevel(node) {
 // get indent level without checking if node should be bypassed
 exports.getLevelLoose = getLevelLoose;
 function getLevelLoose(node) {
+    var originalNode = node;
     var level = 0;
     while (node) {
         if ((!node.parent && _curOpts[node.type]) ||
@@ -133,6 +134,9 @@ function getLevelLoose(node) {
             level++;
         }
         node = node.parent;
+    }
+    if (!_curOpts.TopLevelFunctionBlock && !!_ast.getClosest(originalNode, 'FunctionExpression')) {
+        level -= 1;
     }
     return level;
 }

--- a/test/compare/custom/top-level-indent-exception-config.json
+++ b/test/compare/custom/top-level-indent-exception-config.json
@@ -1,0 +1,5 @@
+{
+    "indent" : {
+        "TopLevelFunctionBlock" : 0
+    }
+}

--- a/test/compare/custom/top-level-indent-exception-in.js
+++ b/test/compare/custom/top-level-indent-exception-in.js
@@ -1,0 +1,15 @@
+(function() {
+
+    // top level block isn't indented
+    var x = 123;
+
+    setTimeout(function() {
+        x();
+    });
+
+}());
+
+// don't mess up other code outside a function scope
+var x = {
+    abc: 123
+};

--- a/test/compare/custom/top-level-indent-exception-out.js
+++ b/test/compare/custom/top-level-indent-exception-out.js
@@ -1,0 +1,15 @@
+(function() {
+
+// top level block isn't indented
+var x = 123;
+
+setTimeout(function() {
+    x();
+});
+
+}());
+
+// don't mess up other code outside a function scope
+var x = {
+    abc: 123
+};


### PR DESCRIPTION
Needed for #46. The implementation is rather crude. Since the new config is off by default, it doesn't affect the existing tests and the new one passes. This may need some follow-up improvements later.

The implementation itself can probably improved as well. Is there a better way to figure out if a node as a FunctionExpression as the parent?
