### PR TITLE
Allow var declarations without init on one line. 

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -234,8 +234,13 @@ exports.VariableDeclaration = function(node){
         if (! i && ! _tk.isComment(_tk.findPrevNonEmpty(idStartToken)) ) {
             _tk.removeAdjacentBefore(idStartToken, 'LineBreak');
         } else if (shouldIndent) {
-            _br.beforeIfNeeded(idStartToken, 'VariableName');
-            _indent.before(idStartToken, indentLevel);
+            // allow declarations without init on a single line
+            if (declarator.init || _br.needsBefore('VariableDeclarationWithoutInit')) {
+                _br.beforeIfNeeded(idStartToken, 'VariableName');
+                _indent.before(idStartToken, indentLevel);
+            } else {
+                _ws.beforeIfNeeded(idStartToken, 'VariableName');
+            }
         } else {
             _ws.beforeIfNeeded(idStartToken, 'VariableName');
         }

--- a/lib/preset/default.json
+++ b/lib/preset/default.json
@@ -65,6 +65,7 @@
             "VariableName" : 1,
             "VariableValue" : 0,
             "VariableDeclaration" : 1,
+            "VariableDeclarationWithoutInit" : 1,
             "WhileStatement" : 1,
             "WhileStatementOpeningBrace" : 0,
             "WhileStatementClosingBrace" : 1

--- a/test/compare/custom/one-line-var-declaration-config.json
+++ b/test/compare/custom/one-line-var-declaration-config.json
@@ -1,0 +1,7 @@
+{
+	"lineBreak" : {
+		"before" : {
+			"VariableDeclarationWithoutInit" : 0
+		}
+	}
+}

--- a/test/compare/custom/one-line-var-declaration-in.js
+++ b/test/compare/custom/one-line-var-declaration-in.js
@@ -1,0 +1,6 @@
+var var1, var2,
+    var3 = [],
+    var4 = {},
+    var5 = [var1, var2, var3];
+
+var x, y, z;

--- a/test/compare/custom/one-line-var-declaration-out.js
+++ b/test/compare/custom/one-line-var-declaration-out.js
@@ -1,0 +1,6 @@
+var var1, var2,
+    var3 = [],
+    var4 = {},
+    var5 = [var1, var2, var3];
+
+var x, y, z;


### PR DESCRIPTION
Fixes #63

This adds lineBreak.before.VariableDeclarationWithoutInit, on by default. When turned off, multi var declarations without init can go on one line, like `var x, y, z;`.
