### PR TITLE
Add another comment indent exception. 

### DIFF
--- a/lib/util/indent.js
+++ b/lib/util/indent.js
@@ -149,6 +149,14 @@ exports.getCommentIndentLevel = function (node) {
         return getLevelLoose(node) + 1;
     }
     var level = 0;
+    // the exceptions below prevent BlockStatement comments within FunctionExpressions within CallExpressions from getting indented
+    // we don't want to apply that fix for any node inside that kind of BlockStatement
+    if (node.type === 'BlockStatement' && node.parent && node.parent.type === 'FunctionExpression' && node.parent.parent && node.parent.parent.type === 'CallExpression') {
+        level++;
+    }
+    if (!_curOpts.TopLevelFunctionBlock && !!_ast.getClosest(node, 'FunctionExpression')) {
+        level--;
+    }
     while (node) {
         if ( _curOpts[node.type] ) {
             if (!(node.parent.type in BYPASS_CHILD_INDENT &&

--- a/test/compare/default/comments-in.js
+++ b/test/compare/default/comments-in.js
@@ -1,0 +1,4 @@
+(function() {
+    // comment
+    x;
+}());

--- a/test/compare/default/comments-out.js
+++ b/test/compare/default/comments-out.js
@@ -1,0 +1,4 @@
+(function() {
+    // comment
+    x;
+}());


### PR DESCRIPTION
Fixes #68 - Bad comment indenting inside FunctionExpression inside CallExpression

Another workaround of the brittle comment indentation system. I wonder if it is feasible to implement something that instead looks at the indentation of the following line and applies the same to the comment? That might require having to process comments later, maybe even after everything else. But at least we wouldn't have to duplicate the indentation system and add all these exceptions.
