### PR TITLE
Change: add vim usage link to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ See [CONTRIBUTING.md](https://github.com/millermedeiros/esformatter/blob/master/
  - [esformatter-diff](https://github.com/piuccio/esformatter-diff) - provides a CLI tool to check and validate a codebase
  - [sublime-esformatter](https://github.com/piuccio/sublime-esformatter) - integrates esformatter into Sublime Text
  - [grunt-esformatter](https://github.com/jzaefferer/grunt-esformatter) - provides a grunt plugin for validating and formatting your projects code formatting
+ - [vim-esformatter](https://gist.github.com/nisaacson/6939960) - integrates esformatter into vim
 
 
 


### PR DESCRIPTION
I am indenting javascript files in vim using the esfomatter command line tool. 

The linked gist provides instructions and perhaps could be helpful for others trying to integrate esformatter with vim
