### PR TITLE
ReturnStatement: Test for whitespace in parens in ReturnStatement

### DIFF
--- a/test/compare/custom/expression_parentheses-in.js
+++ b/test/compare/custom/expression_parentheses-in.js
@@ -24,3 +24,6 @@ madness = (weird,stuff),(45,56)
 (function(){})();
 (function(){}());
 
+function returnTest() {
+  return (x > 1);
+}

--- a/test/compare/custom/expression_parentheses-out.js
+++ b/test/compare/custom/expression_parentheses-out.js
@@ -24,3 +24,6 @@ madness = ( weird, stuff ), ( 45, 56 )
 (function(){})();
 (function(){}());
 
+function returnTest() {
+  return ( x > 1 );
+}


### PR DESCRIPTION
This should adhere to ExpressionOpeningParentheses and ExpressionClosingParentheses, but currently those don't apply in the context of a ReturnStatement.

I've looked into this for a while, trying to reuse hooks/addSpaceInsideExpressionParentheses.js. Since that actually looks at the previous token when the first one isn't the open paren, it can't be used here - the `return` is the startToken value for the ReturnStatement, so we'd have to look at the next token instead.

Maybe there is a way to reuse the logic in that file? If not, I can look into reimplementing it for the ReturnStatement.
