### PR TITLE
ArrayExpression: Test for indent inside multi-VariableDeclaration

### DIFF
--- a/test/compare/default/array_expression-in.js
+++ b/test/compare/default/array_expression-in.js
@@ -20,3 +20,10 @@ var tuples = [
     ],
 ["notify", "progress", "ipsum"]
 ];
+
+var x,
+  y = [
+    "a",
+    "b",
+    "c"
+  ];

--- a/test/compare/default/array_expression-out.js
+++ b/test/compare/default/array_expression-out.js
@@ -18,3 +18,10 @@ var tuples = [
   ],
   ["notify", "progress", "ipsum"]
 ];
+
+var x,
+  y = [
+    "a",
+    "b",
+    "c"
+  ];


### PR DESCRIPTION
When declaring multiple variables and one is a multi-line ArrayExpression, the indent is incorrect.

I've tried to address this inside `hooks/ArrayExpression`, explicitly checking for `node.parent.type === 'VariableDeclarator'. But that isn't reliable, since this problem only occurs when the VariableDeclaration has multiple declarations. [Even when I take that into account](https://gist.github.com/jzaefferer/f6c050da8fb04d9fa1eb), the closing bracket still gets the wrong indentation.
