### PR TITLE
ArrayExpression: Add a test for array expression getting bad whitespace

### DIFF
--- a/test/compare/custom/array_bug-config.json
+++ b/test/compare/custom/array_bug-config.json
@@ -1,0 +1,10 @@
+{
+  "whiteSpace" : {
+    "before" : {
+      "MemberExpressionClosing" : 1
+    },
+    "after" : {
+      "MemberExpressionOpening" : 1
+    }
+  }
+}

--- a/test/compare/custom/array_bug-in.js
+++ b/test/compare/custom/array_bug-in.js
@@ -1,0 +1,5 @@
+[];
+
+this.element;
+
+parts = [];

--- a/test/compare/custom/array_bug-out.js
+++ b/test/compare/custom/array_bug-out.js
@@ -1,0 +1,5 @@
+[];
+
+this.element;
+
+parts = [];


### PR DESCRIPTION
Only happens when MemberExpressionOpening/Closing are set to 1 and a MemberExpression is after (or before?) the empty ArrayExpression.

This three ExpressionStatements in the test are the minimum I found for reproducing the bug. Anything less and the bug disappears.

Haven't yet looked into what is causing this. Was rather painful to produce a minimal testcase...
