### PR TITLE
ObjectExpression: Add test for bad comment indent in nested objects

### DIFF
--- a/test/compare/default/obj_expression-in.js
+++ b/test/compare/default/obj_expression-in.js
@@ -39,3 +39,10 @@ prop: "value"
 });
 }
 });
+
+x = {
+props: {
+// comment
+x: 1
+}
+};

--- a/test/compare/default/obj_expression-out.js
+++ b/test/compare/default/obj_expression-out.js
@@ -55,3 +55,10 @@ define(name, {
       });
   }
 });
+
+x = {
+  props: {
+    // comment
+    x: 1
+  }
+};


### PR DESCRIPTION
A comment before a property of an object expression inside another object expressions gets the wrong indent.
