### PR TITLE
ReturnStatement: More tests for parens in argument

### DIFF
--- a/test/compare/custom/expression_parentheses-in.js
+++ b/test/compare/custom/expression_parentheses-in.js
@@ -32,4 +32,9 @@ function returnTest2() {
   return ( y + 1 );
 }
 
+function returnTest3(amount) {
+  return amount + " result" + (amount > 1 ? "s" : "");
+}
+
+
 fn((1 + 3) + 4);

--- a/test/compare/custom/expression_parentheses-out.js
+++ b/test/compare/custom/expression_parentheses-out.js
@@ -32,4 +32,9 @@ function returnTest2() {
   return ( y + 1 );
 }
 
+function returnTest3(amount) {
+  return amount + " result" + ( amount > 1 ? "s" : "" );
+}
+
+
 fn(( 1 + 3 ) + 4);


### PR DESCRIPTION
Adds a test to check for parens inside BinaryExpression inside the argument of a ReturnStatement.

This is a follow-up to #99, which also was adding tests, but not covering enough special cases.
