### PR TITLE
Call/Function Expression: Test for chained calls with function args

### DIFF
--- a/test/compare/default/call_expression-in.js
+++ b/test/compare/default/call_expression-in.js
@@ -30,6 +30,24 @@ returned.promise().done(foo)
 // comment
 .progress(newDefer.notify);
 
+filter(function() {
+// comment
+x;
+}).map(function() {
+// comment
+y;
+});
+
+var contents;
+contents = this.headers.next()
+.removeClass("ui-state-disabled")
+.css("display", "");
+
+gulp.task('lint', function() {
+return gulp.src('**.js')
+.pipe(jshint())
+.pipe(jshint.reporter(stylish));
+});
 
 // issue #68
 define(function() {

--- a/test/compare/default/call_expression-out.js
+++ b/test/compare/default/call_expression-out.js
@@ -32,6 +32,24 @@ returned.promise().done(foo)
   // comment
   .progress(newDefer.notify);
 
+filter(function() {
+  // comment
+  x;
+}).map(function() {
+  // comment
+  y;
+});
+
+var contents;
+contents = this.headers.next()
+  .removeClass("ui-state-disabled")
+  .css("display", "");
+
+gulp.task('lint', function() {
+  return gulp.src('**.js')
+    .pipe(jshint())
+    .pipe(jshint.reporter(stylish));
+});
 
 // issue #68
 define(function() {


### PR DESCRIPTION
This worked fine in 0.0.10, so the indent refactor likely caused a regression.
