### PR TITLE
Add ThrowStatement hook to add whitespace after 'throw' keyword

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -30,6 +30,7 @@ exports.Params = require('./hooks/Params');
 exports.ReturnStatement = require('./hooks/ReturnStatement');
 exports.SequenceExpression = require('./hooks/SequenceExpression');
 exports.SwitchStatement = require('./hooks/SwitchStatement');
+exports.ThrowStatement = require('./hooks/ThrowStatement');
 exports.TryStatement = require('./hooks/TryStatement');
 exports.UnaryExpression = require('./hooks/UnaryExpression');
 exports.UpdateExpression = require('./hooks/UpdateExpression');

--- a/lib/hooks/ThrowStatement.js
+++ b/lib/hooks/ThrowStatement.js
@@ -1,0 +1,7 @@
+"use strict";
+
+var _ws = require('../whiteSpace/whiteSpace');
+
+module.exports = function ThrowStatement(node) {
+  _ws.after(node.startToken);
+};


### PR DESCRIPTION
This fixes one tiny issue of the many many issues on the keep-br branch. I can't tell why this is even necessary.
