### PR TITLE
Add tests for non-indented comments in front of else statements

### DIFF
--- a/test/compare/jquery/spacing-in.js
+++ b/test/compare/jquery/spacing-in.js
@@ -16,3 +16,14 @@ this.element
     // one more
     prop: "value"
   });
+
+// true?
+if ( true ) {
+  yay();
+// false?
+} else if ( false ) {
+  meh();
+// was active, but active panel is gone
+} else {
+  gone();
+}

--- a/test/compare/jquery/spacing-out.js
+++ b/test/compare/jquery/spacing-out.js
@@ -18,3 +18,14 @@ this.element
 		// one more
 		prop: "value"
 	});
+
+// true?
+if ( true ) {
+	yay();
+// false?
+} else if ( false ) {
+	meh();
+// was active, but active panel is gone
+} else {
+	gone();
+}


### PR DESCRIPTION
Related to #141 and #146. This is about comment indent where it should be possible to have comments in front of an else statement with the same indent as the follow line. As in #146, even if this isn't the default, it should be possible to indenting comments like that and esformatter leaving it alone.
