### PR TITLE
UnaryExpression with typeof operator isn't handled correctly

### DIFF
--- a/test/compare/default/unary_expression-in.js
+++ b/test/compare/default/unary_expression-in.js
@@ -25,3 +25,5 @@ function fn() {
 delete this.bar
 delete      this.amet;delete this.ipsum;
 }
+
+typeof a === "number" ? x : y;

--- a/test/compare/default/unary_expression-out.js
+++ b/test/compare/default/unary_expression-out.js
@@ -27,3 +27,5 @@ function fn() {
   delete this.amet;
   delete this.ipsum;
 }
+
+typeof a === "number" ? x : y;


### PR DESCRIPTION
Currently the space after the `typeof` operator gets removed.
