### PR TITLE
Add tests for custom line breaks and indents with comments

### DIFF
--- a/test/compare/jquery/spacing-in.js
+++ b/test/compare/jquery/spacing-in.js
@@ -24,3 +24,10 @@ while (x) {
 for (i = 0; i < length; i++) {
   y();
 }
+
+ul.outerWidth( Math.max(
+  // Firefox wraps long text (possibly a rounding bug)
+  // so we add 1px to avoid the wrapping (#7513)
+  ul.width( "" ).outerWidth() + 1,
+  this.element.outerWidth()
+) );

--- a/test/compare/jquery/spacing-out.js
+++ b/test/compare/jquery/spacing-out.js
@@ -26,3 +26,10 @@ while ( x ) {
 for ( i = 0; i < length; i++ ) {
 	y();
 }
+
+ul.outerWidth( Math.max(
+	// Firefox wraps long text (possibly a rounding bug)
+	// so we add 1px to avoid the wrapping (#7513)
+	ul.width( "" ).outerWidth() + 1,
+	this.element.outerWidth()
+) );


### PR DESCRIPTION
Here's another oddity. Another example where line breaks are already kept as-is, but indentation isn't. See also #141.
