### PR TITLE
switch statements don't indent correctly

### DIFF
--- a/test/compare/custom/switch_statement-indented-config.json
+++ b/test/compare/custom/switch_statement-indented-config.json
@@ -1,0 +1,23 @@
+{
+    "indent" : {
+        "SwitchStatement" : 1
+    },
+    "whiteSpace" : {
+        "before" : {
+            "SwitchDiscriminantClosing" : 1
+        },
+        "after" : {
+            "SwitchDiscriminantOpening" : 1
+        }
+    },
+    "lineBreak": {
+        "before": {
+            "SwitchOpeningBrace": 1,
+            "SwitchClosingBrace": 1
+        },
+        "after": {
+            "SwitchOpeningBrace": 1,
+            "SwitchClosingBrace": ">= 0"
+        }
+    }
+}

--- a/test/compare/custom/switch_statement-indented-in.js
+++ b/test/compare/custom/switch_statement-indented-in.js
@@ -1,0 +1,23 @@
+switch ( event.keyCode ) {
+    case $.ui.keyCode.ENTER:
+        case $.ui.keyCode.SPACE:
+        // line comment
+        z();
+        break;
+    case $.ui.keyCode.ESCAPE:
+                y();
+            break;
+    default:
+    x();
+}
+
+call(function(){
+    switch (fruit) {
+        case Fruit.APPLE:
+            // line comment
+            exotic();
+            break;
+                default:
+                unknown();
+    }
+});

--- a/test/compare/custom/switch_statement-indented-out.js
+++ b/test/compare/custom/switch_statement-indented-out.js
@@ -1,0 +1,25 @@
+switch ( event.keyCode )
+{
+  case $.ui.keyCode.ENTER:
+  case $.ui.keyCode.SPACE:
+    // line comment
+    z();
+    break;
+  case $.ui.keyCode.ESCAPE:
+    y();
+    break;
+  default:
+    x();
+}
+
+call(function() {
+  switch ( fruit )
+  {
+    case Fruit.APPLE:
+      // line comment
+      exotic();
+      break;
+    default:
+      unknown();
+  }
+});


### PR DESCRIPTION
It seems as though the opening brace is being indented as well when attempting to indent the contents of the `switch` block. The test should be easy enough to read and see what's going on.
