### PR TITLE
Tests for a grunt task formatted according to jQuery style guide

### DIFF
--- a/test/compare/jquery/grunt-task-in.js
+++ b/test/compare/jquery/grunt-task-in.js
@@ -1,0 +1,26 @@
+/*
+ * grunt-esformatter
+ *
+ * Copyright (c) 2013 Jörn Zaefferer, contributors
+ * Licensed under the MIT license.
+ */
+
+'use strict';
+
+var esformatter = require( 'esformatter' );
+
+module.exports = function( grunt ) {
+
+grunt.registerMultiTask( 'esformatter', 'Format JS files', function() {
+	var options = this.options({});
+	this.files.forEach(function( f ) {
+		f.src.filter(function( file ) {
+			return grunt.file.exists( file );
+		}).forEach(function( file ) {
+			var content = grunt.file.read( file );
+			grunt.file.write( file, esformatter.format( content, options ) );
+		});
+	});
+});
+
+};

--- a/test/compare/jquery/grunt-task-out.js
+++ b/test/compare/jquery/grunt-task-out.js
@@ -1,0 +1,26 @@
+/*
+ * grunt-esformatter
+ *
+ * Copyright (c) 2013 Jörn Zaefferer, contributors
+ * Licensed under the MIT license.
+ */
+
+'use strict';
+
+var esformatter = require( 'esformatter' );
+
+module.exports = function( grunt ) {
+
+grunt.registerMultiTask( 'esformatter', 'Format JS files', function() {
+	var options = this.options({});
+	this.files.forEach(function( f ) {
+		f.src.filter(function( file ) {
+			return grunt.file.exists( file );
+		}).forEach(function( file ) {
+			var content = grunt.file.read( file );
+			grunt.file.write( file, esformatter.format( content, options ) );
+		});
+	});
+});
+
+};


### PR DESCRIPTION
Currently fails tests since TopLevelFunctionBlock doesn't recognize this.

This is a bit meta. I guess we can change the sample to something abstract, but since the testsuite for my grunt task was using this for testing, I just kept it intact for now.