### PR TITLE
FunctionExpression: Handle two special cases for TopLevelFunctionBlock

### DIFF
--- a/lib/hooks/FunctionExpression.js
+++ b/lib/hooks/FunctionExpression.js
@@ -36,6 +36,7 @@ exports.format = function FunctionExpression(node) {
 
 
 exports.getIndentEdges = function(node, opts) {
+  // TODO make this a plugin
   if (!opts.TopLevelFunctionBlock && isTopLevelFunctionBlock(node)) {
     return false;
   }
@@ -47,7 +48,12 @@ exports.getIndentEdges = function(node, opts) {
 
 
 function isTopLevelFunctionBlock(node) {
-  return isOfType(node.parent, 'CallExpression') &&
+  // exception for UMD blocks
+  return !(node.params.length === 1 && node.params[0].name === "factory") &&
+    // regular IFEE
+    (isOfType(node.parent, 'CallExpression') ||
+      // module.exports assignment
+      isOfType(node.parent, 'AssignmentExpression')) &&
     !isOfType(node.parent.callee, 'MemberExpression') &&
     isOfType(node.parent.parent, 'ExpressionStatement') &&
     isOfType(node.parent.parent.parent, 'Program');

--- a/test/compare/custom/top-level-indent-exception-in.js
+++ b/test/compare/custom/top-level-indent-exception-in.js
@@ -13,3 +13,28 @@
 var x = {
     abc: 123
 };
+
+module.exports = function() {
+
+    var x = 123;
+
+};
+
+(function( factory ) {
+    if ( typeof define === "function" && define.amd ) {
+        // AMD. Register as an anonymous module.
+        define([
+            "jquery",
+            "./core",
+            "./widget"
+        ], factory );
+    } else {
+        // Browser globals
+        factory( jQuery );
+    }
+}(function( $ ) {
+    return $.widget( "ui.accordion", {
+        version: "@VERSION",
+        options: {}
+    });
+}));

--- a/test/compare/custom/top-level-indent-exception-out.js
+++ b/test/compare/custom/top-level-indent-exception-out.js
@@ -13,3 +13,28 @@ setTimeout(function() {
 var x = {
   abc: 123
 };
+
+module.exports = function() {
+
+var x = 123;
+
+};
+
+(function(factory) {
+  if (typeof define === "function" && define.amd) {
+    // AMD. Register as an anonymous module.
+    define([
+      "jquery",
+      "./core",
+      "./widget"
+    ], factory);
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function($) {
+return $.widget("ui.accordion", {
+  version: "@VERSION",
+  options: {}
+});
+}));


### PR DESCRIPTION
node-style module export assignments apply, UMD wrappers don't. As the comment indicates, this should really be a plugin, but since the option is here, I'm starting with making it work better.

One of several issues I ran into while trying to format jQuery UI's source. My oneliner object plugin is part of that, a few more to come.