### PR TITLE
Update jquery preset to tolerate single line objects

### DIFF
--- a/lib/preset/jquery.json
+++ b/lib/preset/jquery.json
@@ -10,11 +10,17 @@
 
   "lineBreak" : {
     "before" : {
+      "ObjectExpressionOpeningBrace": -1,
+      "ObjectExpressionClosingBrace": -1,
+      "Property": -1,
       "VariableDeclarationWithoutInit" : 0
     },
 
     "after": {
-      "AssignmentOperator": -1
+      "AssignmentOperator": -1,
+      "ObjectExpressionOpeningBrace": -1,
+      "ObjectExpressionClosingBrace": -1,
+      "Property": -1
     }
   },
 
@@ -42,6 +48,7 @@
       "IfStatementConditionalOpening" : 1,
       "MemberExpressionOpening" : 1,
       "ParameterList" : 1,
+      "PropertyValue": -1,
       "SwitchDiscriminantOpening" : 1,
       "WhileStatementConditionalOpening" : 1
     }

--- a/test/compare/jquery/spacing-in.js
+++ b/test/compare/jquery/spacing-in.js
@@ -73,3 +73,8 @@ try {
 } catch(error) {
   console.log(error);
 }
+
+x({ a: 1 });
+y({
+  a: 1
+});

--- a/test/compare/jquery/spacing-out.js
+++ b/test/compare/jquery/spacing-out.js
@@ -75,3 +75,8 @@ try {
 } catch ( error ) {
 	console.log( error );
 }
+
+x( { a: 1 } );
+y( {
+	a: 1
+} );


### PR DESCRIPTION
This disables a big chunk of useful formatting, but until I can figure out a better solution, this is preferable over messing up existing acceptable code.