### PR TITLE
Introduce PropertyValueLast configuration to format single-line objects

### DIFF
--- a/lib/preset/jquery.json
+++ b/lib/preset/jquery.json
@@ -35,6 +35,7 @@
       "IfStatementConditionalClosing" : 1,
       "IIFEClosingParentheses": 1,
       "MemberExpressionClosing" : 1,
+      "ObjectExpressionClosingBrace": 1,
       "ParameterList" : 1,
       "SwitchDiscriminantClosing" : 1,
       "WhileStatementConditionalClosing" : 1

--- a/test/compare/custom/object_expression-3-config.json
+++ b/test/compare/custom/object_expression-3-config.json
@@ -1,0 +1,24 @@
+{
+  "lineBreak" : {
+    "before" : {
+      "ObjectExpressionOpeningBrace": -1,
+      "ObjectExpressionClosingBrace": -1,
+      "Property": -1
+    },
+
+    "after": {
+      "ObjectExpressionOpeningBrace": -1,
+      "ObjectExpressionClosingBrace": -1,
+      "Property": -1
+    }
+  },
+
+  "whiteSpace" : {
+    "before": {
+      "ObjectExpressionClosingBrace": 1
+    },
+    "after" : {
+      "PropertyValue": -1
+    }
+  }
+}

--- a/test/compare/custom/object_expression-3-in.js
+++ b/test/compare/custom/object_expression-3-in.js
@@ -1,0 +1,20 @@
+x({ a:1});
+y({
+a: 1
+});
+$.each({ div: "#list1", ul: "#navigation", dl: "#accordion-dl" });
+
+var x ={ foo:{ bar: true} };
+var y= {a: b, c:d, e:{ f: g } };
+x = {
+	props: {
+	// comment
+	x: 1
+	}
+};
+x = {
+b: function b() {
+a();
+},
+a: b
+};

--- a/test/compare/custom/object_expression-3-out.js
+++ b/test/compare/custom/object_expression-3-out.js
@@ -1,0 +1,20 @@
+x({ a: 1 });
+y({
+  a: 1
+});
+$.each({ div: "#list1", ul: "#navigation", dl: "#accordion-dl" });
+
+var x = { foo: { bar: true } };
+var y = { a: b, c: d, e: { f: g } };
+x = {
+  props: {
+    // comment
+    x: 1
+  }
+};
+x = {
+  b: function b() {
+    a();
+  },
+  a: b
+};

--- a/test/compare/jquery/spacing-in.js
+++ b/test/compare/jquery/spacing-in.js
@@ -78,7 +78,23 @@ x({ a: 1 });
 y({
   a: 1
 });
+$.each( { div: "#list1", ul: "#navigation", dl: "#accordion-dl" } );
 
 (function($) {
   x;
 }(jQuery));
+
+var x = {foo:{bar: true}};
+var y = {a: b, c: d, e:{ f: g}};
+x = {
+  props: {
+    // comment
+    x: 1
+  }
+};
+x={
+  b:function b() {
+    a();
+  },
+  a:b
+};

--- a/test/compare/jquery/spacing-out.js
+++ b/test/compare/jquery/spacing-out.js
@@ -80,7 +80,23 @@ x( { a: 1 } );
 y( {
 	a: 1
 } );
+$.each( { div: "#list1", ul: "#navigation", dl: "#accordion-dl" } );
 
 ( function( $ ) {
 x;
 }( jQuery ) );
+
+var x = { foo: { bar: true } };
+var y = { a: b, c: d, e: { f: g } };
+x = {
+	props: {
+		// comment
+		x: 1
+	}
+};
+x = {
+	b: function b() {
+		a();
+	},
+	a: b
+};


### PR DESCRIPTION
When an object expression is on a single line, this settings allows adding a space after the last value, which PropertyValue by itself can't provide, since it would also add spaces before commas.

Adds a custom test both this setting, which also includes other settings to allow single-line object expressions, taken from the jQuery preset.

---

I'm open to suggestions for a better name or better logic to match the last property in the object expression hook.
