### PR TITLE
ForStatement improvements

### DIFF
--- a/lib/hooks/ForStatement.js
+++ b/lib/hooks/ForStatement.js
@@ -6,24 +6,15 @@ var _limit = require('../limit');
 
 
 exports.format = function ForStatement(node) {
+  var semi_1 = _tk.findNext(node.startToken, ';');
+  var semi_2 = _tk.findPrev(node.body.startToken, ';');
+  _ws.limit(semi_1, 'ForStatementSemicolon');
+  _ws.limit(semi_2, 'ForStatementSemicolon');
+
   var expressionStart = _tk.findNext(node.startToken, '(');
   var expressionEnd = _tk.findPrev(node.body.startToken, ')');
-
   _limit.around(expressionStart, 'ForStatementExpressionOpening');
   _limit.around(expressionEnd, 'ForStatementExpressionClosing');
-
-  var semi_1,
-    semi_2;
-  if (node.test) {
-    semi_1 = _tk.findPrev(node.test.startToken, ';');
-    semi_2 = _tk.findNext(node.test.endToken, ';');
-  } else {
-    if (node.init) semi_1 = _tk.findNext(node.init.endToken, ';');
-    if (node.update) semi_2 = _tk.findPrev(node.update.startToken, ';');
-  }
-
-  if (semi_1) _ws.limit(semi_1, 'ForStatementSemicolon');
-  if (semi_2) _ws.limit(semi_2, 'ForStatementSemicolon');
 
   if (node.body.type === 'BlockStatement') {
     var bodyStart = node.body.startToken;

--- a/test/compare/custom/for_statement-config.json
+++ b/test/compare/custom/for_statement-config.json
@@ -1,0 +1,10 @@
+{
+  "whiteSpace" : {
+    "before" : {
+      "ForStatementExpressionClosing" : 1
+    },
+    "after" : {
+      "ForStatementExpressionOpening" : 1
+    }
+  }
+}

--- a/test/compare/custom/for_statement-in.js
+++ b/test/compare/custom/for_statement-in.js
@@ -1,0 +1,33 @@
+for (i=0; i<n;++i ) {x(); }
+
+for(;i<n;++i){
+  x();
+}
+
+for ( ;   ; ++i ) {
+  x();
+}
+
+for ( i = 0; ; ) {
+  x();
+}
+
+for ( ; i < n; ++i ) {
+  for ( ; j > 0; --j ) {
+    x();
+  }
+}
+
+for(;;  ) {
+  x();
+}
+
+function foo() {
+  for (var c   =   this._bindings.length, d;c--;)
+    x += 1;
+  return -1;
+}
+
+for  (  i = 0;i<   10;i++) foo();
+for (i=10; i <   10; i++   )
+  bar();

--- a/test/compare/custom/for_statement-out.js
+++ b/test/compare/custom/for_statement-out.js
@@ -1,0 +1,35 @@
+for ( i = 0; i < n; ++i ) {
+  x();
+}
+
+for ( ; i < n; ++i ) {
+  x();
+}
+
+for ( ;; ++i ) {
+  x();
+}
+
+for ( i = 0;; ) {
+  x();
+}
+
+for ( ; i < n; ++i ) {
+  for ( ; j > 0; --j ) {
+    x();
+  }
+}
+
+for ( ;; ) {
+  x();
+}
+
+function foo() {
+  for ( var c = this._bindings.length, d; c--; )
+    x += 1;
+  return -1;
+}
+
+for ( i = 0; i < 10; i++ ) foo();
+for ( i = 10; i < 10; i++ )
+  bar();

--- a/test/compare/default/for_statement-out.js
+++ b/test/compare/default/for_statement-out.js
@@ -33,7 +33,7 @@ for (;;) {
 
 // 7 : indent + no braces
 function foo() {
-  for (var c = this._bindings.length, d; c--; )
+  for (var c = this._bindings.length, d; c--;)
     if (d = this._bindings[c], d._listener === a && d.context === b) return c;
   return -1
 }

--- a/test/compare/jquery/spacing-in.js
+++ b/test/compare/jquery/spacing-in.js
@@ -26,6 +26,9 @@ while (x) {
 for (i = 0; i < length; i++) {
   y();
 }
+for ( ; i < length; i++ ) {
+  y();
+}
 
 function x() {
   return something &&

--- a/test/compare/jquery/spacing-out.js
+++ b/test/compare/jquery/spacing-out.js
@@ -28,6 +28,9 @@ while ( x ) {
 for ( i = 0; i < length; i++ ) {
 	y();
 }
+for ( ; i < length; i++ ) {
+	y();
+}
 
 function x() {
 	return something &&


### PR DESCRIPTION
I'm trying to get a space in front of the semicolon when there's no init on a ForStatement. The call `_limit.around(expressionStart, 'ForStatementExpressionOpening');` looks like it should provide that, but that isn't enough.

Before I dig deeper or try to add more configuration, I wanted to share my test. Seems like there should be a simple fix here.