### PR TITLE
use locally installed esformatter if available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 __*
 coverage/
-node_modules/
+/node_modules/

--- a/bin/esformatter
+++ b/bin/esformatter
@@ -1,3 +1,40 @@
 #!/usr/bin/env node
+"use strict";
 
-require('../lib/cli.js').parse( process.argv.slice(2) );
+// resolve allow us to load the locally installed esformatter instead of using
+// the global version
+var requireResolve = require('resolve').sync;
+var path = require('path');
+var dirname = path.dirname;
+var pathResolve = path.resolve;
+
+var argv = process.argv.slice(2);
+
+// if user sets a config file we use that as the base directory to start the
+// search because we assume that some settings aren't backwards compatible
+// otherwise we just use the process.cwd()
+var opts = require('../lib/cli.js').parse(argv);
+var basedir = opts.config ?
+  pathResolve(dirname(opts.config)) :
+  process.cwd();
+
+var cliPath;
+try {
+  cliPath = requireResolve('esformatter', {
+    basedir: basedir
+  });
+  cliPath = pathResolve(dirname(cliPath), './cli.js');
+} catch (err) {
+  // fallback to this version instead
+  cliPath = '../lib/cli.js';
+}
+
+var cli = require(cliPath);
+// until v0.5 the cli module only exposed a single `parse` method, after v0.6
+// we expose 2 methods to allow processing the data before executing the
+// command (all the logic above)
+if ('run' in cli) {
+  cli.run(cli.parse(argv));
+} else {
+  cli.parse(argv);
+}

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -27,6 +27,15 @@ optimist
 exports.parse = function(str) {
   var argv = optimist.parse(str);
 
+  if (argv.plugins) {
+    argv.plugins = argv.plugins.split(',');
+  }
+
+  return argv;
+};
+
+
+exports.run = function(argv) {
   if (argv.help) {
     optimist.showHelp();
     process.exit(0);
@@ -35,10 +44,6 @@ exports.parse = function(str) {
   if (argv.version) {
     console.log('esformatter v' + require('../package.json').version);
     process.exit(0);
-  }
-
-  if (argv.plugins) {
-    argv.plugins = argv.plugins.split(',');
   }
 
   run(argv);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esformatter",
-  "version": "0.5.1",
+  "version": "0.6.0-alpha",
   "description": "ECMAScript code beautifier/formatter",
   "main": "lib/esformatter.js",
   "bin": {
@@ -42,15 +42,16 @@
     "mockery": "^1.4.0"
   },
   "dependencies": {
+    "debug": "^0.7.4",
     "mout": ">=0.9 <2.0",
-    "rocambole": ">=0.5 <2.0",
-    "rocambole-token": "^1.1.2",
-    "rocambole-node": "~1.0",
     "optimist": "~0.6.0",
-    "stdin": "*",
-    "strip-json-comments": "~0.1.1",
+    "resolve": "^1.1.5",
+    "rocambole": ">=0.5 <2.0",
+    "rocambole-node": "~1.0",
+    "rocambole-token": "^1.1.2",
     "semver": "~2.2.1",
-    "debug": "^0.7.4"
+    "stdin": "*",
+    "strip-json-comments": "~0.1.1"
   },
   "license": "MIT"
 }

--- a/test/bin/config.json
+++ b/test/bin/config.json
@@ -1,0 +1,4 @@
+{
+  "preset": "default",
+  "root": true
+}

--- a/test/bin/node_modules/esformatter/lib/cli.js
+++ b/test/bin/node_modules/esformatter/lib/cli.js
@@ -1,0 +1,10 @@
+'use strict';
+
+exports.parse = function() {
+  return null;
+};
+
+exports.run = function() {
+  console.log('fake-esformatter v0.0.0-alpha');
+  process.exit(0);
+};

--- a/test/bin/node_modules/esformatter/lib/fake.js
+++ b/test/bin/node_modules/esformatter/lib/fake.js
@@ -1,0 +1,1 @@
+throw new Error('this is just a fake file and should not be executed');

--- a/test/bin/node_modules/esformatter/package.json
+++ b/test/bin/node_modules/esformatter/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "name": "esformatter",
+  "description": "this is a fake version of esformatter just to test if CLI can use local version",
+  "version": "0.0.0-alpha",
+  "main": "lib/fake.js"
+}

--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -159,6 +159,13 @@ describe('Command line interface', function() {
     expect(formattedFile).to.equal(helpers.readOut('/custom/commented_config').replace(/true/, 'false'));
   });
 
+  // it should use locally installed esformatter version if available
+  filePath = path.join(__dirname + '/compare/custom/commented_config-in.js');
+  configPath = path.join(__dirname + '/bin/config.json');
+  spawnEsformatter('local install', '--config ' + configPath + ' ' + filePath, function(formattedFile) {
+    expect(formattedFile.trim()).to.equal('fake-esformatter v0.0.0-alpha');
+  });
+
   // in place option should modify the input file
   var originalInPlace = path.join(__dirname + '/compare/default/inplace-in.js');
   var cpInPlace = path.join(__dirname + '/compare/default/inplace-in.js.copy');


### PR DESCRIPTION
**WIP**

this patch allow us to use the locally installed esformatter version (based on `cwd` or config file or file path).

still pending tests tho..

closes #190