### PR TITLE
ConditionalExpression: indent even if consequent is on the same line as the test

### DIFF
--- a/lib/hooks/ConditionalExpression.js
+++ b/lib/hooks/ConditionalExpression.js
@@ -24,4 +24,10 @@ exports.getIndentEdges = function(node) {
       endToken: node.endToken.next
     };
   }
+  if (_tk.findInBetween(node.consequent.endToken, node.alternate.startToken, _tk.isBr)) {
+    return {
+      startToken: node.consequent.endToken.next,
+      endToken: node.endToken.next
+    };
+  }
 };

--- a/test/compare/default/conditional_expression-in.js
+++ b/test/compare/default/conditional_expression-in.js
@@ -37,3 +37,7 @@ num == null ?
 
     // Return just the object
     ( num < 0 ? this[ this.length + num ] : this[ num ] );
+
+// issue #253
+var format = isSameDate(startDate, endDate) ? this._oneDayLabelFormat :
+'event-multiple-day-duration';

--- a/test/compare/default/conditional_expression-out.js
+++ b/test/compare/default/conditional_expression-out.js
@@ -38,3 +38,7 @@ num == null ?
 
   // Return just the object
   (num < 0 ? this[this.length + num] : this[num]);
+
+// issue #253
+var format = isSameDate(startDate, endDate) ? this._oneDayLabelFormat :
+  'event-multiple-day-duration';

--- a/test/compare/jquery/spacing-in.js
+++ b/test/compare/jquery/spacing-in.js
@@ -42,14 +42,10 @@ ul.outerWidth( Math.max(
   this.element.outerWidth()
 ) );
 
-this.isMultiLine =
-  // Textareas are always multi-line
-  isTextarea ? true :
-  // Inputs are always single-line, even if inside a contentEditable element
-  // IE also treats inputs as contentEditable
-  isInput ? false :
-  // All other element types are determined by whether or not they're contentEditable
-  this.element.prop( "isContentEditable" );
+function x() {
+  return this.indeterminate ? false :
+    Math.min( this.options.max, Math.max( this.min, newValue ) );
+}
 
 if ( event.target !== that.element[ 0 ] &&
     event.target !== menuElement &&

--- a/test/compare/jquery/spacing-out.js
+++ b/test/compare/jquery/spacing-out.js
@@ -44,14 +44,10 @@ ul.outerWidth( Math.max(
 	this.element.outerWidth()
 ) );
 
-this.isMultiLine =
-	// Textareas are always multi-line
-	isTextarea ? true :
-	// Inputs are always single-line, even if inside a contentEditable element
-	// IE also treats inputs as contentEditable
-	isInput ? false :
-	// All other element types are determined by whether or not they're contentEditable
-	this.element.prop( "isContentEditable" );
+function x() {
+	return this.indeterminate ? false :
+		Math.min( this.options.max, Math.max( this.min, newValue ) );
+}
 
 if ( event.target !== that.element[ 0 ] &&
 		event.target !== menuElement &&


### PR DESCRIPTION
Updates the expected output for the jQuery preset - nested conditionals should stack indent.

Fixes #253

This is Miller's patch from #253, dealing with the jQuery preset failure by updating the expected output. Also adds a non-nested conditional there.