### PR TITLE
Fix the CLI --diff-unified flag.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -65,7 +65,7 @@ exports.run = function(argv) {
     return;
   }
 
-  if (argv.i && (argv.diff || argv.diffUnified)) {
+  if (argv.i && (argv.diff || argv['diff-unified'])) {
     logError(
       'Error: "--diff" and "--diff-unified" flags ' +
       'can\'t be used together with the "-i" flag.'
@@ -179,7 +179,7 @@ function toConsole(source, file, argv) {
   try {
     var result;
 
-    if (argv.diff || argv.diffUnified) {
+    if (argv.diff || argv['diff-unified']) {
       var method = argv.diff ? 'chars' : 'unified';
       if (!supportsColor) {
         method = 'unifiedNoColor';


### PR DESCRIPTION
Minimist doesn't convert CLI args to camel case, which was preventing the `--diff-unified` flag from working.