### PR TITLE
fix config merge issue which reported at #336

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -14,7 +14,7 @@ var merge = require('mout/object/merge');
 var get = require('mout/object/get');
 var isObject = require('mout/lang/isObject');
 var userHome = require('user-home');
-
+var isEmpty = require('mout/lang/isEmpty');
 
 // ---
 
@@ -90,10 +90,11 @@ function getRc(filePath, customOptions) {
   var basedir = filePath ? path.dirname(filePath) : process.cwd();
   var cwd = process.cwd();
   var rc = findAndMergeConfigs(basedir);
-  if (!rc && basedir !== cwd) {
+  if (isEmpty(rc) && basedir !== cwd) {
     rc = findAndMergeConfigs(cwd);
   }
-  return merge(rc || getGlobalConfig(), customOptions);
+  var tmpConfig = !isEmpty(rc) ? rc : getGlobalConfig();
+  return merge(tmpConfig, customOptions);
 }
 
 
@@ -168,5 +169,3 @@ function loadAndParseConfig(file) {
     );
   }
 }
-
-


### PR DESCRIPTION
Check config if it is empty by using `mout/lang/isEmpty` instead of `!config` expression