### PR TITLE
avoid applying FunctionReservedWord whitespace to class method definition

### DIFF
--- a/lib/hooks/FunctionExpression.js
+++ b/lib/hooks/FunctionExpression.js
@@ -12,7 +12,7 @@ exports.format = function FunctionExpression(node) {
 
   if (node.id) {
     _ws.limit(node.id.startToken, 'FunctionName');
-  } else {
+  } else if (node.startToken.value === 'function') {
     _ws.limit(node.startToken, 'FunctionReservedWord');
   }
 

--- a/test/compare/custom/function_expression_bug-config.json
+++ b/test/compare/custom/function_expression_bug-config.json
@@ -1,0 +1,17 @@
+{
+  "indent" : {
+    "value": "  "
+  },
+
+  "whiteSpace" : {
+    "value" : " ",
+    "before" : {
+      "ParameterList" : -1
+    },
+
+    "after" : {
+      "FunctionReservedWord": 1,
+      "ParameterList" : -1
+    }
+  }
+}

--- a/test/compare/custom/function_expression_bug-in.js
+++ b/test/compare/custom/function_expression_bug-in.js
@@ -1,0 +1,9 @@
+class Bug {
+  fix(author) {}
+}
+
+class BugTwo {
+  fix( author ) {}
+}
+
+var foo = function () {}

--- a/test/compare/custom/function_expression_bug-out.js
+++ b/test/compare/custom/function_expression_bug-out.js
@@ -1,0 +1,9 @@
+class Bug {
+  fix(author) {}
+}
+
+class BugTwo {
+  fix( author ) {}
+}
+
+var foo = function () {}


### PR DESCRIPTION
Hi @millermedeiros, hope things are well!

Today I've been trying to debug https://github.com/maxogden/standard-format/issues/75 and I think I have half of it figured out.

Here is a summary of this specific issue:
Before:
```js
class Bug {
  fix(author) {}
}
```
After:
```js
class Bug {
  fix( author) {}
}
```

It looks like `FunctionExpression.js` is applying to method definitions improperly and adds `whitespace.after.FunctionReservedWord` just before the parameter list.

 It looks like the code asumes the token is "function" if its not the name of the function itself, but this does not apply to the ES6 method definitions. So, to fix this, I just added a condition to check if its 'function'.

I also added a test under `custom` to illustrate that the problem is fixed with this update.

I'm still getting my bearings on the esformatter codebase, so please correct me if I missed something.