### PR TITLE
https://github.com/millermedeiros/esformatter/issues/373

### DIFF
--- a/lib/hooks/Params.js
+++ b/lib/hooks/Params.js
@@ -21,7 +21,7 @@ exports.format = function Params(node) {
     params.forEach(function(param, i) {
       // if only one param or last one there are no commas to look for
       if (i < params.length - 1) {
-        _ws.limit(_tk.findNext(param.startToken, ','), 'ParameterComma');
+        _limit.around(_tk.findNext(param.startToken, ','), 'ParameterComma');
       }
 
       // Default parameters are AssignmentExpressions as params

--- a/test/compare/custom/function-expression-config.json
+++ b/test/compare/custom/function-expression-config.json
@@ -1,4 +1,9 @@
 {
+    "lineBreak" : {
+        "after": {
+            "ParameterComma": 0
+        }
+    },
     "whiteSpace" : {
         "before" : {
             "FunctionName" : 1,

--- a/test/compare/custom/function-expression-in.js
+++ b/test/compare/custom/function-expression-in.js
@@ -121,3 +121,7 @@ var object = {
 // Named function expression with body
 (function booz(a,b,c){something();}());
 (function boozArg(){something();}());
+
+// issue #373
+var foo = function(a,
+				   b){};

--- a/test/compare/custom/function-expression-out.js
+++ b/test/compare/custom/function-expression-out.js
@@ -177,3 +177,6 @@ var object = {
 (function boozArg () {
   something();
 }());
+
+// issue #373
+var foo = function (a, b) {};

--- a/test/compare/default/function_expression-in.js
+++ b/test/compare/default/function_expression-in.js
@@ -66,3 +66,7 @@ var foo = function        () {
 var defaultParams = function defaults(z, x=      1, y   =  2) {
   return z + x + y;
 }
+
+// issue #373
+var foo = function(a,
+b){};

--- a/test/compare/default/function_expression-out.js
+++ b/test/compare/default/function_expression-out.js
@@ -71,3 +71,7 @@ var foo = function() {
 var defaultParams = function defaults(z, x = 1, y = 2) {
   return z + x + y;
 }
+
+// issue #373
+var foo = function(a,
+  b) {};


### PR DESCRIPTION
Line breaks around ParameterComma not enforced for FunctionExpression

Added line break check around ParameterComma for FunctionExpression