### PR TITLE
Remove semver dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "rocambole-node": "~1.0",
     "rocambole-token": "^1.1.2",
     "rocambole-whitespace": "^1.0.0",
-    "semver": "~2.2.1",
     "stdin": "*",
     "strip-json-comments": "~0.1.1",
     "supports-color": "^1.3.1",


### PR DESCRIPTION
Requiring an insecure version of semver which was also unused. (https://nodesecurity.io/advisories/semver_redos)

Removing this dependency since it was unused (Ran tests and they still pass).

Found this via bitHound: [![bitHound Dependencies](https://www.bithound.io/github/millermedeiros/esformatter/badges/dependencies.svg)](https://www.bithound.io/github/millermedeiros/esformatter/master/dependencies/npm)

With this change on my fork: [![bitHound Dependencies](https://www.bithound.io/github/gtanner/esformatter/badges/dependencies.svg)](https://www.bithound.io/github/gtanner/esformatter/master/dependencies/npm).
