### PR TITLE
Change \r\n to \n when reading source files

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -143,7 +143,8 @@ function expandGlobs(filePaths) {
 
 function getSource(file) {
   try {
-    return fs.readFileSync(file).toString();
+    var text = fs.readFileSync(file).toString();
+    return text.replace(/\r\n?|[\n\u2028\u2029]/g, "\n");
   } catch (e) {
     logError('Error: Can\'t read source file. Exception: ' + e.message);
   }


### PR DESCRIPTION
Before, running esformatter on OS X and Windows gave different results.

Changing the \r\n to \n fixes the inconsistent output.