### PR TITLE
fix SwitchCaseColon when not immediately followed by another case

### DIFF
--- a/lib/hooks/SwitchCase.js
+++ b/lib/hooks/SwitchCase.js
@@ -13,17 +13,19 @@ exports.format = function SwitchCase(node) {
     _ws.limitBefore(node.test.startToken, 1);
   }
   var endToken = node.endToken;
+  
+  var colon = _tk.findNext(node.startToken, function (node) {
+    return node.value === ':';
+  });
 
-  if (endToken.value === ':') {
-    limit.before(endToken, 'SwitchCaseColon');
-    limit.after(endToken, 'SwitchCaseColon');
-  } else {
-    // endToken might be ":" or "break" or ";"
-    var breakKeyword = _tk.findPrev(endToken.next, 'break');
-    if (breakKeyword) {
-      limit.before(breakKeyword, 'BreakKeyword');
-      limit.after(endToken, 'BreakKeyword');
-    }
+  limit.before(colon, 'SwitchCaseColon');
+  limit.after(colon, 'SwitchCaseColon');
+
+  // endToken might be ":" or "break" or ";"
+  var breakKeyword = _tk.findPrev(endToken.next, 'break');
+  if (breakKeyword) {
+    limit.before(breakKeyword, 'BreakKeyword');
+    limit.after(endToken, 'BreakKeyword');
   }
 };
 

--- a/lib/preset/default.json
+++ b/lib/preset/default.json
@@ -130,6 +130,7 @@
       "ReturnStatement" : -1,
       "SwitchOpeningBrace" : 0,
       "SwitchClosingBrace" : ">=1",
+      "SwitchCaseColon": 0,
       "ThisExpression" : -1,
       "ThrowStatement" : ">=1",
       "TryKeyword": -1,

--- a/test/compare/custom/switch_statement-in.js
+++ b/test/compare/custom/switch_statement-in.js
@@ -11,6 +11,18 @@ switch ( event.keyCode ) {
     x();
 }
 
+switch ( event.keyCode ) {
+    case $.ui.keyCode.ENTER            :
+        whatever = 'nothing';
+        break
+    case $.ui.keyCode.ESCAPE 
+    :
+        whatever = 'something';
+            break;
+    default:
+    x();
+}
+
 call(function(){
     switch (fruit) {
         case Fruit.APPLE:

--- a/test/compare/custom/switch_statement-out.js
+++ b/test/compare/custom/switch_statement-out.js
@@ -15,6 +15,20 @@ default:
   x();
 }
 
+switch ( event.keyCode )
+{
+case $.ui.keyCode.ENTER:
+  whatever = 'nothing';
+  break
+
+case $.ui.keyCode.ESCAPE:
+  whatever = 'something';
+  break;
+
+default:
+  x();
+}
+
 call(function() {
   switch ( fruit )
   {


### PR DESCRIPTION
The previous implementation of SwitchCaseColon only worked when the endToken of the node was ':', which is not always true.

This PR makes it look for the next ':' after the case node and applies the whitespace rules to it.