### PR TITLE
Fix incorrect removal of space around async functions

### DIFF
--- a/lib/hooks/FunctionDeclaration.js
+++ b/lib/hooks/FunctionDeclaration.js
@@ -10,7 +10,14 @@ exports.format = function FunctionDeclaration(node) {
   if (node.id) {
     _limit.around(node.id.startToken, 'FunctionName');
   }
-  if (node.generator) {
+  // babel-eslint reports async functions as generators.
+  //
+  // Make sure the generator function is not an async function before removing
+  // the whitespace.
+  //
+  // This will prevent a function such as `async function fun() {}` being
+  // converted to `asyncfunction fun() {}`.
+  if (node.generator && !node.async) {
     var genToken = _tk.findNextNonEmpty(node.startToken);
     _ws.limitBefore(genToken, 'FunctionGeneratorAsterisk');
   }

--- a/test/compare/default/function_declaration-in.js
+++ b/test/compare/default/function_declaration-in.js
@@ -101,3 +101,6 @@ function*gen() {
   yield '123';
   yield '456';
 }
+
+async function asyncFunction() {
+}

--- a/test/compare/default/function_declaration-out.js
+++ b/test/compare/default/function_declaration-out.js
@@ -112,3 +112,6 @@ function* gen() {
   yield '123';
   yield '456';
 }
+
+async function asyncFunction() {
+}

--- a/test/compare/default/function_expression-in.js
+++ b/test/compare/default/function_expression-in.js
@@ -86,3 +86,5 @@ var foo = function*() {
 let index = _.findLast(test, function (t) {
   return obj && obj[t]
 })
+
+var asyncFunctionExpression = async function() {};

--- a/test/compare/default/function_expression-out.js
+++ b/test/compare/default/function_expression-out.js
@@ -91,3 +91,5 @@ var foo = function*() {
 let index = _.findLast(test, function(t) {
   return obj && obj[t]
 })
+
+var asyncFunctionExpression = async function() {};


### PR DESCRIPTION
babel-eslint reports async functions as generators.

Make sure the generator function is not an async function before removing
the whitespace.

This will prevent a function such as `async function fun() {}` being
converted to `asyncfunction fun() {}`.