### PR TITLE
Update npm run

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "glob": "^5.0.3",
     "minimist": "^1.1.1",
     "mout": ">=0.9 <2.0",
-    "npm-run": "^2.0.0",
+    "npm-run": "^3.0.0",
     "resolve": "^1.1.5",
     "rocambole": ">=0.7 <2.0",
     "rocambole-indent": "^2.0.4",


### PR DESCRIPTION
Previously npm run was using the `spawn-sync` module, which is a c extension.  This PR updates to the 3.x branch which [no longer uses that module](https://github.com/timoxley/npm-run/issues/5), switching to the core `spawnSync`.  This drops support for node <0.12 and thus would be a major version bump.  I don't know how this project manages old node support, but this is here for whenever you don't mind dropping that :)