### PR TITLE
Preserve indent for Literals on newline after LogicalExpression

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,13 +3,11 @@
 exports.shouldIndentChild = shouldIndentChild;
 function shouldIndentChild(parent, child, opts) {
   // this will avoid indenting objects/arrays/functions twice if they
-  // are on left/right of a BinaryExpression, LogicalExpression or
+  // are on the right of a BinaryExpression, LogicalExpression or
   // UnaryExpression
   if (!child || !opts[parent.type + '.' + child.type]) {
     return false;
   }
 
-  var left = child.left;
-  var right = child.right;
-  return !right || (!opts[right.type] && !opts[left.type]);
+  return !child.right || !opts[child.right.type];
 }

--- a/test/compare/default/logical_expression-in.js
+++ b/test/compare/default/logical_expression-in.js
@@ -43,3 +43,10 @@ let property = property || {
 prop = prop || {
     foo: '111'
 }
+
+// issue #421
+let foo = foo ||
+42;
+
+let bar = bar() ||
+42;

--- a/test/compare/default/logical_expression-out.js
+++ b/test/compare/default/logical_expression-out.js
@@ -44,3 +44,10 @@ let property = property || {
 prop = prop || {
   foo: '111'
 }
+
+// issue #421
+let foo = foo ||
+  42;
+
+let bar = bar() ||
+  42;


### PR DESCRIPTION
A fix for #421 

In `shouldIndentChild` I wasn't sure why the `child.left` option was being considered in the decision to indent or not. Maybe there's a reason for that that I'm not aware of.

In any case, the indent option for CallExpression is 1 be default, so the check on line 14 gets confused. That's why

```
let foo = foo ||
  42;
```

will indent properly but

```
let bar = bar() ||
  42;
```

won't