### PR TITLE
Bug Report with new failing test related to ObjectExpression

### DIFF
--- a/test/compare/custom/arrow-function-object-pattern-config.json
+++ b/test/compare/custom/arrow-function-object-pattern-config.json
@@ -1,0 +1,26 @@
+{
+  "lineBreak" : {
+    "before" : {
+      "ObjectExpressionOpeningBrace" : -1,
+      "ObjectExpressionClosingBrace" : -1,
+      "Property": -1
+    },
+    "after" : {
+      "ObjectExpressionOpeningBrace" : -1,
+      "ObjectExpressionClosingBrace" : -1,
+      "Property": -1
+    }
+  },
+  "whiteSpace" : {
+    "before" : {
+      "ObjectExpressionOpeningBrace": -1,
+      "ObjectExpressionClosingBrace": -1,
+      "Property": -1
+    },
+    "after" : {
+      "ObjectExpressionOpeningBrace": -1,
+      "ObjectExpressionClosingBrace": -1,
+      "Property": -1
+    }
+  }
+}

--- a/test/compare/custom/arrow-function-object-pattern-in.js
+++ b/test/compare/custom/arrow-function-object-pattern-in.js
@@ -1,0 +1,3 @@
+t.test('abstract', t => followsAbstract({ t, setup, teardown }))
+
+t.test('abstract', t => followsAbstract({t, setup, teardown}))

--- a/test/compare/custom/arrow-function-object-pattern-out.js
+++ b/test/compare/custom/arrow-function-object-pattern-out.js
@@ -1,0 +1,3 @@
+t.test('abstract', t => followsAbstract({ t, setup, teardown }))
+
+t.test('abstract', t => followsAbstract({t, setup, teardown}))


### PR DESCRIPTION
Bug Report: 

Expected: When disabling config for ObjectExpressionOpeningBrace, ObjectExpressionClosingBrace and Property, we would expect these tests to pass.